### PR TITLE
Revert "Bump eslint-plugin-vue from 7.18.0 to 7.19.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7464,9 +7464,9 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.19.1.tgz",
-      "integrity": "sha512-e2pD7nW2sTY04ThH+66BgToNwC4n6dqfNhKE+ypdJFtZgn3Zn+nP8ZEIFPG0PGqCKQ3qxy8dJk1bzUsuQd3ANA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.18.0.tgz",
+      "integrity": "sha512-ceDXlXYMMPMSXw7tdKUR42w9jlzthJGJ3Kvm3YrZ0zuQfvAySNxe8sm6VHuksBW0+060GzYXhHJG6IHVOfF83Q==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vue/eslint-config-airbnb": "^5.3.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^6.8.0",
-    "eslint-plugin-vue": "^7.19.1",
+    "eslint-plugin-vue": "^7.18.0",
     "node-sass": "^6.0.1",
     "sass": "^1.42.1",
     "sass-loader": "^8.0.2",


### PR DESCRIPTION
Reverts overstarry/covid-19_visualizer#84